### PR TITLE
Updated POM file, downloads factions and mcore and installs them.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
     <artifactId>DragonTravel</artifactId>
     <version>0.0.0.10-SNAPSHOT</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <factions_version>2.2.2</factions_version>
         <factions_url>http://dev.bukkit.org/media/files/753/8/Factions.jar</factions_url>
         <mcore_version>6.9.1</mcore_version>


### PR DESCRIPTION
This improves upon PR https://github.com/Phiwa/DragonTravel/pull/6 by making the maven building portable (platform independent) once again!

I tried to make this as easy as possible for you to read and edit when you update your factions and mcore dependencies.

```
    <properties>
        <factions_version>2.2.2</factions_version>
        <factions_url>http://dev.bukkit.org/media/files/753/8/Factions.jar</factions_url>
        <mcore_version>6.9.1</mcore_version>
        <mcore_url>http://dev.bukkit.org/media/files/753/422/mcore.jar</mcore_url>
    </properties>
```

Changing the versions and URL will effect all the other places in the pom that they are called for. Edit once, deploy EVERYWHERE :dancer: 
