### PR TITLE
Added message which displays the estimate travel time

### DIFF
--- a/src/main/java/eu/phiwa/dt/filehandlers/Config.java
+++ b/src/main/java/eu/phiwa/dt/filehandlers/Config.java
@@ -44,6 +44,10 @@ public class Config {
 	  // New options in version 0.2			
 		if(!DragonTravelMain.config.isSet("PToggleDefault"))
 			DragonTravelMain.config.set("PToggleDefault", true);
+
+        // New options in version 0.3
+        if(!DragonTravelMain.config.isSet("ShowEstimatedTravelDuration"))
+            DragonTravelMain.config.set("ShowEstimatedTravelDuration", true);
 		
 		
 	  // Update the file version

--- a/src/main/java/eu/phiwa/dt/filehandlers/Messages.java
+++ b/src/main/java/eu/phiwa/dt/filehandlers/Messages.java
@@ -72,6 +72,14 @@ public class Messages {
         	DragonTravelMain.config.set("Messages.Flights.Error.OnlySigns", "&cThis command has been disabled by the admin, you can only use flights using signs.");      
         if (DragonTravelMain.config.get("Messages.Stations.Error.NotCreateStationWithRandomstatName") == null)
         	DragonTravelMain.config.set("Messages.Stations.Error.NotCreateStationWithRandomstatName", "&cYou cannot create a staion with the name of the RandomDest.");
+        if (DragonTravelMain.config.get("Messages.General.Successful.EstimatedDuration") == null)
+            DragonTravelMain.config.set("Messages.General.Successful.EstimatedDuration", "&aEstimated flight duration &f{duration}&a.");
+        if (DragonTravelMain.config.get("Messages.General.Time.Hours") == null)
+            DragonTravelMain.config.set("Messages.General.Time.Hours", " hours, ");
+        if (DragonTravelMain.config.get("Messages.General.Time.Minutes") == null)
+            DragonTravelMain.config.set("Messages.General.Time.Minutes", " minutes and ");
+        if (DragonTravelMain.config.get("Messages.General.Time.Seconds") == null)
+            DragonTravelMain.config.set("Messages.General.Time.Seconds", " seconds");
 	}
 	private void noLongerRequiredMessages() {
 		// DragonTravelMain.config.set("example key", null);

--- a/src/main/java/eu/phiwa/dt/movement/Travels.java
+++ b/src/main/java/eu/phiwa/dt/movement/Travels.java
@@ -310,9 +310,12 @@ public class Travels {
 	
 		RyeDragon dragon = DragonTravelMain.listofDragonriders.get(player);		
 		
-		if(destination.getWorld().getName() == player.getWorld().getName())
+		if(destination.getWorld().getName() == player.getWorld().getName()) {
 			dragon.startTravel(destination, false);
-		else
+            if (DragonTravelMain.config.getBoolean("ShowEstimatedTravelDuration"))
+                player.sendMessage(DragonTravelMain.messagesHandler.getMessage("Messages.General.Successful.EstimatedDuration").replace("{duration}", getTravelTimeString(player.getLocation(), destination)));
+        }
+        else
 			dragon.startTravel(destination, true);
 		
 	}
@@ -326,4 +329,23 @@ public class Travels {
 		else
 			return player.getLocation().getYaw();
 	}
+
+    private static String getTravelTimeString(Location start, Location destination) {
+        double travelDuration = (start.distance(destination)) / (DragonTravelMain.speed * 20);
+
+        int hours = (int) travelDuration / 3600;
+        int minutes = (int) (travelDuration % 3600) / 60;
+        int seconds = (int) travelDuration % 60;
+
+        StringBuilder string = new StringBuilder();
+        if (hours > 0)
+            string.append(hours + DragonTravelMain.messagesHandler.getMessage("Messages.General.Time.Hours"));
+
+        if (minutes > 0)
+            string.append(minutes + DragonTravelMain.messagesHandler.getMessage("Messages.General.Time.Minutes"));
+
+        string.append(seconds + DragonTravelMain.messagesHandler.getMessage("Messages.General.Time.Seconds"));
+
+        return string.toString();
+    }
 }

--- a/src/main/resources/eu/phiwa/dt/filehandlers/config.yml
+++ b/src/main/resources/eu/phiwa/dt/filehandlers/config.yml
@@ -1,5 +1,5 @@
 File:
-    Version: 0.2
+    Version: 0.3
 
     
 ################################
@@ -150,3 +150,8 @@ OnlySigns: false
 # Choose whether travels to a player are allowed (true) or denied (false) by default
 # Default: true
 PToggleDefault: true
+
+# <<< Show a message how long the travel will take? >>>
+# Choose whether this message will be send or not.
+# Default: true
+ShowEstimatedTravelDuration: true

--- a/src/main/resources/eu/phiwa/dt/filehandlers/messages/messages-en.yml
+++ b/src/main/resources/eu/phiwa/dt/filehandlers/messages/messages-en.yml
@@ -36,7 +36,7 @@
 #       and please report all bugs you find, otherwise I can't fix them. ;)
 
 File:
-    Version: 0.2
+    Version: 0.3
     Language: 'English'
 
 Messages:
@@ -47,12 +47,18 @@ Messages:
             DismountedToStart: '&aYou cancelled your journey and were brought back to your starting-point.'
             ToggledPTravelOn: '&aYou now allow player-travels to you.'
             ToggledPTravelOff: '&aYou now don''t allow player-travels to you.'
+            EstimatedDuration: '&aEstimated flight duration &f{duration}&a.'
         Error:        
             NoPermission: '&cYou do not have the permission to use this.'
             NotMounted: '&cYou are not mounted.'
             RequiredItemMissing: '&cYou do not have the required item in your inventory to use the plugin.'        
             DatabaseCorrupted: '&cThe database is corrupted, could not load the entry. Please inform the admin.'
             ReachedDragonLimit: '&cThe server already reached its limit, you cannot spawn another dragon, please wait for another player to dismount.'
+        Time:
+            Hours: ' hours, '
+            Minutes: ' minutes and '
+            Seconds: ' seconds'
+
     Payment:
         Resources:
             Successful:


### PR DESCRIPTION
One of my friends suggested this feature and I really liked the idea, so I decided to add it myself quickly and submit a Pull Request for it!

This Pull Request adds an extra message line whenever a player starts a travel on the same world - it will calculate a rough estimate of how long the flight will take based on the distance between the two locations and the travel speed.

![screenshot 2014-01-10 16 00 40](https://f.cloud.github.com/assets/551935/1888084/346332e2-7a08-11e3-8dc4-4796bb2c7746.png)
