### PR TITLE
Initial Commit of Towny Town Spawn Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,13 @@
             <systemPath>${project.basedir}/lib/mcore.jar</systemPath>
         </dependency>
         <dependency>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.90.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/Towny.jar</systemPath>
+        </dependency>
+        <dependency>
             <groupId>fr.neatmonster</groupId>
             <artifactId>ncpplugin</artifactId>
             <version>static</version>

--- a/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
@@ -11,6 +11,7 @@ import eu.phiwa.dragontravel.core.movement.stationary.StationaryDragon;
 import eu.phiwa.dragontravel.core.movement.travel.TravelEngine;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -259,6 +260,30 @@ public class DragonManager {
         CheatProtectionHandler.unexemptPlayerFromCheatChecks(player);
         DragonPlayerDismountEvent event = new DragonPlayerDismountEvent(player, dragon, customDismountLoc);
         Bukkit.getPluginManager().callEvent(event);
+    }
+    
+    /*
+	 * I created this method to check to see if a dragon is a DT Dragon. However,
+	 * this doesn't work @ CreatureSpawnEvent. Perhaps dragons aren't added to these
+	 * lists until later?
+	*/
+    public boolean isDragonTravelDragon(Entity e){
+    	ConcurrentHashMap<Player, IRyeDragon> dragons = this.getRiderDragons();
+		ConcurrentHashMap<String, StationaryDragon> statdragons = this.getStationaryDragons();
+    	for(OfflinePlayer p : Bukkit.getServer().getOfflinePlayers()){
+			IRyeDragon dragon = dragons.get(p);
+			if(dragon!=null){
+				if(e == dragon.getEntity()){
+					return true;
+				}
+			}
+		}
+		for (StationaryDragon sDragon : statdragons.values()){
+			if(sDragon.getDragon().getEntity() == e){
+				return true;
+			}
+		}
+		return false;
     }
 
     public HashMap<UUID, Long> getDamageReceipts() {

--- a/src/main/java/eu/phiwa/dragontravel/core/DragonTravel.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/DragonTravel.java
@@ -15,6 +15,7 @@ import eu.phiwa.dragontravel.core.listeners.BlockListener;
 import eu.phiwa.dragontravel.core.listeners.EntityListener;
 import eu.phiwa.dragontravel.core.listeners.HeroesListener;
 import eu.phiwa.dragontravel.core.listeners.PlayerListener;
+import eu.phiwa.dragontravel.core.listeners.TownyListener;
 import eu.phiwa.dragontravel.core.movement.DragonType;
 import eu.phiwa.dragontravel.core.movement.flight.Flight;
 import eu.phiwa.dragontravel.core.movement.flight.FlightEditor;
@@ -174,6 +175,9 @@ public class DragonTravel extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new BlockListener(), this);
         if (Bukkit.getPluginManager().getPlugin("Heroes") != null) {
             Bukkit.getPluginManager().registerEvents(new HeroesListener(), this);
+        }
+        if(Bukkit.getPluginManager().getPlugin("Towny") != null) {
+        	Bukkit.getPluginManager().registerEvents(new TownyListener(), this);
         }
     }
 

--- a/src/main/java/eu/phiwa/dragontravel/core/commands/DragonTravelCommands.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/commands/DragonTravelCommands.java
@@ -229,7 +229,8 @@ public final class DragonTravelCommands {
         DragonTravel.getInstance().getDragonManager().dismount(player, false);
     }
 
-    @Console
+    @SuppressWarnings("deprecation")
+	@Console
     @Command(aliases = {"ptoggle"},
             desc = "Toggle whether you can recieve player dragon travels",
             usage = "/dt ptoggle [-y|-n]",
@@ -300,7 +301,8 @@ public final class DragonTravelCommands {
         sender.sendMessage(ChatColor.GREEN + "Home set!"); //TODO: Add to messages
     }
 
-    @Console
+    @SuppressWarnings("deprecation")
+	@Console
     @Command(aliases = {"flight"},
             desc = "Start a Flight",
             usage = "/dt flight <flight name> [player=you]",
@@ -400,7 +402,8 @@ public final class DragonTravelCommands {
         }
     }
 
-    @Command(aliases = {"ptravel", "player"},
+    @SuppressWarnings("deprecation")
+	@Command(aliases = {"ptravel", "player"},
             desc = "Travel to another player",
             usage = "/dt ptravel <player>",
             min = 1, max = 1,
@@ -506,6 +509,30 @@ public final class DragonTravelCommands {
             return;
         try {
             DragonManager.getDragonManager().getTravelEngine().toFactionHome(player, true);
+        } catch (DragonException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    @Command(aliases = {"tspawn"},
+            desc = "Travel to your town spawn",
+            usage = "/dt tspawn")
+    //@CommandPermissions({"dt.start.tspawn.command"})
+    public static void startTownSpawnTravel(CommandContext args, CommandSender sender) throws CommandException {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.General.Error.NoConsole"));
+            return;
+        }
+        Player player = (Player) sender;
+
+        if (Bukkit.getPluginManager().getPlugin("Towny") == null) {
+            player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.TownyNotInstalled"));
+            return;
+        }
+        if (!DragonTravel.getInstance().getPaymentManager().chargePlayer(ChargeType.TRAVEL_TOTOWNSPAWN, player))
+            return;
+        try {
+            DragonManager.getDragonManager().getTravelEngine().toTownSpawn(player, true);
         } catch (DragonException e) {
             e.printStackTrace();
         }

--- a/src/main/java/eu/phiwa/dragontravel/core/filehandlers/Config.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/filehandlers/Config.java
@@ -22,6 +22,7 @@ public class Config {
     private boolean requireItemFlight;
     private boolean requireItemTravelCoordinates;
     private boolean requireItemTravelFactionhome;
+    private boolean requireItemTravelTownSpawn;
     private boolean requireItemTravelHome;
     private boolean requireItemTravelPlayer;
     private boolean requireItemTravelRandom;
@@ -101,6 +102,7 @@ public class Config {
         requireItemTravelPlayer = config.getBoolean("RequiredItem.For.toPlayer", false);
         requireItemTravelHome = config.getBoolean("RequiredItem.For.toHome", false);
         requireItemTravelFactionhome = config.getBoolean("RequiredItem.For.toFactionhome", false);
+        requireItemTravelTownSpawn = config.getBoolean("RequiredItem.For.toTownSpawn", false);
         requireItemFlight = config.getBoolean("RequiredItem.For.Flight", false);
         dismountAtExactLocation = config.getBoolean("DismountAtExactLocation", false);
         requireSkyLight = config.getBoolean("RequireSkyLight", false);
@@ -241,6 +243,10 @@ public class Config {
 
     public boolean isRequireItemTravelFactionhome() {
         return requireItemTravelFactionhome;
+    }
+    
+    public boolean isRequireItemTravelTownSpawn() {
+        return requireItemTravelTownSpawn;
     }
 
     public void setRequireItemTravelFactionhome(boolean requireItemTravelFactionhome) {

--- a/src/main/java/eu/phiwa/dragontravel/core/filehandlers/Messages.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/filehandlers/Messages.java
@@ -95,11 +95,16 @@ public class Messages {
             messages.set("Messages.Flights.Error.OnlySigns", "&cThis command has been disabled by the admin, you can only use flights using signs.");
         if (messages.get("Messages.Stations.Error.NotCreateStationWithRandomstatName") == null)
             messages.set("Messages.Stations.Error.NotCreateStationWithRandomstatName", "&cYou cannot create a staion with the name of the RandomDest.");
-
+        // Towny Addon
+        if (messages.get("Messages.Towny.Error.NoTown") == null)
+            messages.set("Messages.Towny.Error.NoTown", ": &cYou do not have a town.");
+        if(messages.get("Messages.Towny.Error.TownyNotInstalled") == null)
+        	messages.set("Messages.Towny.Error.TownyNotInstalled", ": &cTowny is not installed");
         // v0.0.0.17
         if (messages.get("Messages.Factions.Error.NotYourFaction") == null)
             messages.set("Messages.Factions.Error.NotYourFaction", ": &cThis is not your faction.");
-
+        if(messages.get("Messages.Factions.Error.FactionsNotInstalled") == null)
+        	messages.set("Messages.Factions.Error.FactionsNotInstalled", ": &cFactions is not installed");
         // 0.5
         if (messages.get("Messages.General.Error.BelowMinMountHeight") == null)
             messages.set("Messages.General.Error.BelowMinMountHeight", "&cYou are below the minimum height required to mount a dragon. Minimum height is &f{minheight}&c.");
@@ -117,6 +122,8 @@ public class Messages {
             messages.set("Messages.Travels.Successful.TravellingToPlayer", "&aTravelling to &f{playername}&a.");
         if (messages.get("Messages.Travels.Successful.TravellingToFactionHome") == null)
             messages.set("Messages.Travels.Successful.TravellingToFactionHome", "&aTravelling to the faction home.");
+        if (messages.get("Messages.Travels.Successful.TravellingToTownSpawn") == null)
+            messages.set("Messages.Travels.Successful.TravellingToTownSpawn", "&aTravelling to the town spawn.");
         if (messages.get("Messages.General.Error.RequireSkyLight") == null)
             messages.set("Messages.General.Error.RequireSkyLight", "&cYou must have access to sky light!");
         if (messages.get("Messages.General.Error.NoConsole") == null)

--- a/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/ChargeType.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/ChargeType.java
@@ -9,6 +9,7 @@ public enum ChargeType {
     TRAVEL_TOCOORDINATES("dt.nocost.ctravel"),
     TRAVEL_TOHOME("dt.nocost.home"),
     TRAVEL_TOFACTIONHOME("dt.nocost.fhome"),
+    TRAVEL_TOTOWNSPAWN("dt.nocost.tspawn"),
     FLIGHT("dt.nocost.flight"),
     SETHOME("dt.nocost.home.set"),;
 

--- a/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/EconomyPaymentHandler.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/EconomyPaymentHandler.java
@@ -56,6 +56,9 @@ public class EconomyPaymentHandler implements PaymentHandler {
             case TRAVEL_TOFACTIONHOME:
                 amount = DragonTravel.getInstance().getConfig().getDouble("Payment.Economy.Prices.toFactionhome");
                 break;
+            case TRAVEL_TOTOWNSPAWN:
+                amount = DragonTravel.getInstance().getConfig().getDouble("Payment.Economy.Prices.toTownSpawn");
+                break;
             case SETHOME:
                 amount = DragonTravel.getInstance().getConfig().getDouble("Payment.Economy.Prices.setHome");
                 break;

--- a/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/ResourcesPaymentHandler.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/hooks/payment/ResourcesPaymentHandler.java
@@ -44,6 +44,9 @@ public class ResourcesPaymentHandler implements PaymentHandler {
             case TRAVEL_TOFACTIONHOME:
                 amount = DragonTravel.getInstance().getConfig().getInt("Payment.Resources.Prices.toFactionhome");
                 break;
+            case TRAVEL_TOTOWNSPAWN:
+                amount = DragonTravel.getInstance().getConfig().getInt("Payment.Resources.Prices.toTownSpawn");
+                break;
             case SETHOME:
                 amount = DragonTravel.getInstance().getConfig().getInt("Payment.Resources.Prices.setHome");
                 break;

--- a/src/main/java/eu/phiwa/dragontravel/core/listeners/EntityListener.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/listeners/EntityListener.java
@@ -3,13 +3,13 @@ package eu.phiwa.dragontravel.core.listeners;
 import eu.phiwa.dragontravel.core.DragonTravel;
 import eu.phiwa.dragontravel.core.hooks.server.IRyeDragon;
 import eu.phiwa.dragontravel.nms.v1_8_R3.RyeDragon;
+
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
@@ -18,16 +18,18 @@ public class EntityListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onCreatureSpawn(CreatureSpawnEvent event) {
-		if (event.getSpawnReason() != SpawnReason.CUSTOM)
+		/*
+		 * I discovered this was breaking the WorldGuard/Towny Spawn Bypassing. Perhaps
+		 * a spawnreason is not being set correctly?
+		*/
+		/*if (event.getSpawnReason() != SpawnReason.CUSTOM)
 			return;
-
+		*/
 		if (!event.getEntity().getType().toString().equals("ENDER_DRAGON"))
 			return;
-
 		if (!event.isCancelled())
 			return;
-
-		if (DragonTravel.getInstance().getConfigHandler().isIgnoreAntiMobspawnAreas())
+		if (DragonTravel.getInstance().getConfigHandler().isIgnoreAntiMobspawnAreas())			
 			event.setCancelled(false);
 	}
 

--- a/src/main/java/eu/phiwa/dragontravel/core/listeners/TownyListener.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/listeners/TownyListener.java
@@ -1,0 +1,33 @@
+package eu.phiwa.dragontravel.core.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.entity.EnderDragon;
+import com.palmergames.bukkit.towny.event.MobRemovalEvent;
+import eu.phiwa.dragontravel.core.DragonTravel;
+import eu.phiwa.dragontravel.nms.v1_8_R3.RyeDragon;
+
+public class TownyListener implements Listener
+{
+	/*
+	Initial attempt to try to block the entity removal of towny for DragonTravel Dragons, can't seem to get
+	this to work. Maybe You can help? For now, default towny settings 
+	*/
+	/*
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onEnderDragonRemoval(MobRemovalEvent e)
+	{
+		if(e.getEntityType() != null){
+			if (DragonTravel.getInstance().getConfigHandler().isOnlydragontraveldragons() && e.getEntity() instanceof RyeDragon){
+				e.setCancelled(true);
+			}
+			if (DragonTravel.getInstance().getConfigHandler().isAlldragons() && e.getEntity() instanceof EnderDragon){
+				e.setCancelled(true);
+			}
+			if(e.getEntity().getType().toString()=="ENDER_DRAGON"){
+                e.setCancelled(true);				
+			}
+		}
+	}*/
+}

--- a/src/main/java/eu/phiwa/dragontravel/core/listeners/TownyListener.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/listeners/TownyListener.java
@@ -3,31 +3,30 @@ package eu.phiwa.dragontravel.core.listeners;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.entity.EnderDragon;
 import com.palmergames.bukkit.towny.event.MobRemovalEvent;
 import eu.phiwa.dragontravel.core.DragonTravel;
-import eu.phiwa.dragontravel.nms.v1_8_R3.RyeDragon;
 
 public class TownyListener implements Listener
 {
 	/*
-	Initial attempt to try to block the entity removal of towny for DragonTravel Dragons, can't seem to get
-	this to work. Maybe You can help? For now, default towny settings 
-	*/
-	/*
+	 * This prevents Towny from Removing DragonTravel dragons that enter a removal region from outside
+	 */
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onEnderDragonRemoval(MobRemovalEvent e)
 	{
 		if(e.getEntityType() != null){
-			if (DragonTravel.getInstance().getConfigHandler().isOnlydragontraveldragons() && e.getEntity() instanceof RyeDragon){
-				e.setCancelled(true);
-			}
-			if (DragonTravel.getInstance().getConfigHandler().isAlldragons() && e.getEntity() instanceof EnderDragon){
-				e.setCancelled(true);
-			}
-			if(e.getEntity().getType().toString()=="ENDER_DRAGON"){
-                e.setCancelled(true);				
-			}
+			if (!e.getEntity().getType().toString().equals("ENDER_DRAGON"))
+				return;
+
+			if (e.isCancelled())
+				return;
+
+			if (DragonTravel.getInstance().getConfigHandler().isIgnoreAntiMobspawnAreas())
+			{
+				if(DragonTravel.getInstance().getDragonManager().isDragonTravelDragon(e.getEntity())){
+					e.setCancelled(true);
+				}		
+			}			
 		}
-	}*/
+	}
 }

--- a/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
@@ -191,22 +191,20 @@ public class TravelEngine {
     }
     
     public void toTownSpawn(Player player, Boolean checkForStation) throws DragonException {
-
+    	Resident res = null;
+        Location tspawn = null;
+        boolean hasTown = false;
+        
         if (Bukkit.getPluginManager().getPlugin("Towny") == null) {
             player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.TownyNotInstalled"));
             return;
         }
-
         if (DragonTravel.getInstance().getConfigHandler().isRequireItemTravelTownSpawn()) {
             if (!player.getInventory().contains(DragonTravel.getInstance().getConfigHandler().getRequiredItem()) && !player.hasPermission("dt.notrequireitem.travel")) {
                 player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.General.Error.RequiredItemMissing"));
                 return;
             }
         }
-
-        Resident res = null;
-        Location tspawn = null;
-        boolean hasTown = false;
         try {
 			res = TownyUniverse.getDataSource().getResident(player.getName());
 		} catch (NotRegisteredException e1) {
@@ -228,9 +226,9 @@ public class TravelEngine {
 				}
           		hasTown = true;
           	}
-         }else{
-				player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.NoTown"));
-         }
+        }else{
+        	player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.NoTown"));
+        }
         
         if (!hasTown) {
         	player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.NoTown"));

--- a/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
@@ -2,6 +2,12 @@ package eu.phiwa.dragontravel.core.movement.travel;
 
 import com.massivecraft.factions.entity.Faction;
 import com.massivecraft.factions.entity.UPlayer;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+
 import eu.phiwa.dragontravel.api.DragonException;
 import eu.phiwa.dragontravel.core.DragonTravel;
 import eu.phiwa.dragontravel.core.hooks.server.IRyeDragon;
@@ -182,6 +188,56 @@ public class TravelEngine {
             player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Factions.Error.FactionHasNoHome"));
         } else
             travel(player, faction.getHome().asBukkitLocation(), checkForStation, DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Travels.Successful.TravellingToFactionHome"), DragonType.FACTION_TRAVEL);
+    }
+    
+    public void toTownSpawn(Player player, Boolean checkForStation) throws DragonException {
+
+        if (Bukkit.getPluginManager().getPlugin("Towny") == null) {
+            player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.TownyNotInstalled"));
+            return;
+        }
+
+        if (DragonTravel.getInstance().getConfigHandler().isRequireItemTravelTownSpawn()) {
+            if (!player.getInventory().contains(DragonTravel.getInstance().getConfigHandler().getRequiredItem()) && !player.hasPermission("dt.notrequireitem.travel")) {
+                player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.General.Error.RequiredItemMissing"));
+                return;
+            }
+        }
+
+        Resident res = null;
+        Location tspawn = null;
+        boolean hasTown = false;
+        try {
+			res = TownyUniverse.getDataSource().getResident(player.getName());
+		} catch (NotRegisteredException e1) {
+			hasTown = false;
+		}
+        if(res!=null){
+            Town town = null;
+          	try {
+                town = res.getTown();
+                
+				} catch (NotRegisteredException e) {
+					hasTown = false;
+				}
+          	if(town!=null){
+          		try {
+					tspawn = town.getSpawn();
+				} catch (TownyException e) {
+					hasTown = false;
+				}
+          		hasTown = true;
+          	}
+         }else{
+				player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.NoTown"));
+         }
+        
+        if (!hasTown) {
+        	player.sendMessage(DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Towny.Error.NoTown"));
+            return;
+        } else{
+            travel(player, tspawn, checkForStation, DragonTravel.getInstance().getMessagesHandler().getMessage("Messages.Travels.Successful.TravellingToTownSpawn"), DragonType.FACTION_TRAVEL);
+        }
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -112,6 +112,7 @@ Payment:
             toCoordinates: 5.0
             toHome: 5.0
             toFactionhome: 5.0
+            toTownSpawn: 5.0
             setHome: 5.0
             Flight: 5.0
     Resources:
@@ -124,6 +125,7 @@ Payment:
             toCoordinates: 5
             toHome: 5
             toFactionhome: 5
+            toTownSpawn: 5
             setHome: 5
             Flight: 5
 
@@ -149,6 +151,7 @@ RequiredItem:
         toPlayer: false
         toCoordinates: false
         toFactionhome: false
+        toTownSpawn: false
         toHome: false
         Flight: false
     

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: eu.phiwa.dragontravel.core.DragonTravel
 authors: [Phiwa, x3nec]
 version: ${project.version}
 load: POSTWORLD
-softdepend: [Vault, AntiCheat, NoCheatPlus, Factions, Heroes]
+softdepend: [Vault, AntiCheat, NoCheatPlus, Factions, Heroes, Towny]
 permissions:
     dt.*:
         default: op


### PR DESCRIPTION
Everything works, might need some official phiwa touchup ;) Only thing is if you have Towny set to remove EnderDragons in the Towny config, it will remove DragonTravel dragons regardless of the various measures I tried to stop it from doing so. The default Towny config doesn't remove EnderDragons, so most users won't notice an issue, but my server has Enderdragons in the overworld and the removal of them when attacking towns is sometimes necessary. See if you can get it to allow EnderDragons to spawn despite the settings? Check out TownyListener.java