### PR TITLE
Player dismount height

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "verify",
+            "type": "shell",
+            "command": "mvn -B verify",
+            "group": "build"
+        },
+        {
+            "label": "package",
+            "type": "shell",
+            "command": "mvn package",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "mvn -B test",
+            "group": "test"
+        }
+    ]
+}

--- a/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/movement/travel/TravelEngine.java
@@ -183,6 +183,17 @@ public class TravelEngine {
 
         IRyeDragon dragon = DragonTravel.getInstance().getDragonManager().getRiderDragons().get(player);
         dragon.setCustomDragonName(ChatColor.translateAlternateColorCodes('&', destName));
+        
+        // Fix player got fall damage by temporary subtract 5 from station height
+        // TODO: We need to discuss about how to better fix this in future
+        // Replace dragon by other mob can make this fix invalid and get player killed
+        // This will only happen if station recorded above height 5
+        double fixFallingDamageHeight = destination.getY();
+        if (fixFallingDamageHeight >= 5)
+        {
+            destination.setY(fixFallingDamageHeight - 5);
+        }
+        
         dragon.startTravel(destination, interworld, dragonType);
 
     }


### PR DESCRIPTION
fixed #53

Important:
```
// Fix player got fall damage by temporary subtract 5 from station height
// TODO: We need to discuss about how to better fix this in future
// Replace dragon by other mob can make this fix invalid and get player killed
// This will only happen if station recorded above height 5
```