### PR TITLE
Fix: Player got falling damage when dismount

### DIFF
--- a/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
@@ -216,6 +216,27 @@ public class DragonManager {
             // Teleport player to a safe location
             Location saveTeleportLoc = getSafeLandingLoc(player.getLocation());
 
+            // Set player invulnerable to avoid fall damage
+            player.setInvulnerable(true);
+
+            // Async method to remove invulnerable status after few seconds
+
+            // Passing player into a runnable in line requires final variable
+            final Player finalPlayer = player;
+            Runnable playerRemoveInvulnerable = new Runnable() {
+                @Override
+                public void run() {
+                    finalPlayer.setInvulnerable(false);
+                }
+            };
+
+            // Fire the async method
+            Bukkit.getScheduler().runTaskLaterAsynchronously(
+                DragonTravel.getInstance(),
+                playerRemoveInvulnerable,
+                60    // 3 seconds
+            );
+
             // Eject player and remove dragon from world
             entity.eject();
             entity.remove();

--- a/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
@@ -216,26 +216,34 @@ public class DragonManager {
             // Teleport player to a safe location
             Location saveTeleportLoc = getSafeLandingLoc(player.getLocation());
 
-            // Set player invulnerable to avoid fall damage
-            player.setInvulnerable(true);
-
             // Async method to remove invulnerable status after few seconds
+            //
+            // This hack have conflict with this situation:
+            // If a player have invulnerable set to true for unknown reason, and not gonna to set false back in a while,
+            // then once this player take a travel, he will unexpected lose invulnerable after dismount.
+            //
+            // Only do things if player not already in invulnerable status
+            if (player.isInvulnerable() == false) {
 
-            // Passing player into a runnable in line requires final variable
-            final Player finalPlayer = player;
-            Runnable playerRemoveInvulnerable = new Runnable() {
-                @Override
-                public void run() {
-                    finalPlayer.setInvulnerable(false);
-                }
-            };
+                // Set player invulnerable to avoid fall damage
+                player.setInvulnerable(true);
 
-            // Fire the async method
-            Bukkit.getScheduler().runTaskLaterAsynchronously(
-                DragonTravel.getInstance(),
-                playerRemoveInvulnerable,
-                60    // 3 seconds
-            );
+                // Passing player into a runnable in line requires final variable
+                final Player finalPlayer = player;
+                Runnable playerRemoveInvulnerable = new Runnable() {
+                    @Override
+                    public void run() {
+                        finalPlayer.setInvulnerable(false);
+                    }
+                };
+
+                // Fire the async method
+                Bukkit.getScheduler().runTaskLaterAsynchronously(
+                        DragonTravel.getInstance(),
+                        playerRemoveInvulnerable,
+                        60    // 3 seconds
+                );
+            }
 
             // Eject player and remove dragon from world
             entity.eject();


### PR DESCRIPTION
```
close #53
```

This time I use async method to do this:  
first I set player invulnerable to true, this can avoid damage for the player.  
then use async method to set invulnerable to false after 3 second,  
this should enough for him to fall.

A event listener solution certainly better than "invulnerable hack",  
but that have too much job to do.

For me, I feel not good when your magic without comment everywhere.  
The thing is, when you try to do same things but use method different than
"Bukkit new developer tutorial & guide", as your personal style...  
or even just use some API, I, or the after contributors, are not here to DECOMPILE your code.  

If now I want to implement the "on demand event listen" solution instead of "invulnerable hack",  
I need to know where to put my "traveling player array".  
So I start read code from main method and one line after another,  
to figure out where are you placing similar things.  
In this process, I don't want to care about how exactly the code to implement human design.  
Just like any "HelloWorld" program that doesn't need to care about how the graphic card and HDMI protocol or anything else to work.  
So I need the "green things"(comment) says "Oh here I do some stuff because I want to...", "The process to dismount player: one two three four five", "I put these variable here because..."  
By read the green things I can fast a lot to know if a new things join in, where to put it,  
or if I want to edit something, where to find.

OK yet, I know how bad is "tell the open source author you should do things like this".
Just my two cents about somebody is can't even understand what happened in "onLoad" method.  
Sometimes, for better OTHER human readable, I even not to simplify
```
if (player.isInvulnerable() == false)
```
to
```
if (!player.isInvulnerable())
```