### PR TITLE
Disallow manual unmount of the player

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.phiwa</groupId>
     <artifactId>DragonTravel</artifactId>
-    <version>01.008.02</version>
+    <version>01.008.03</version>
     <build>
         <resources>
             <resource>

--- a/src/main/java/eu/phiwa/dragontravel/core/listeners/EntityListener.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/listeners/EntityListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.spigotmc.event.entity.EntityDismountEvent;
 
 public class EntityListener implements Listener {
 
@@ -65,5 +66,17 @@ public class EntityListener implements Listener {
 		IRyeDragon dragon = DragonTravel.getInstance().getDragonManager().getRiderDragons().get(player);
 		dragon.getEntity().remove();
 		DragonTravel.getInstance().getDragonManager().getRiderDragons().remove(player);
+	}
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPlayerUnmount(EntityDismountEvent event) {
+
+		if (!(event.getEntity() instanceof Player))
+			return;
+
+		Player player = (Player) event.getEntity();
+
+		if (!DragonTravel.getInstance().getDragonManager().getRiderDragons().containsKey(player))
+			return;
+		event.setCancelled(true);
 	}
 }


### PR DESCRIPTION
When the player tries to unmount manually from the dragon (using shift or whatever), catch the event and cancel it.
Player can still unmount normal entities like minecarts, horses and so on.
Fixes #74 