### PR TITLE
Fixed Issue #82 - Player can dismount with shift click

### DIFF
--- a/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
+++ b/src/main/java/eu/phiwa/dragontravel/core/DragonManager.java
@@ -70,10 +70,16 @@ public class DragonManager {
         return player;
     }
 
-    // TODO: Optimize for better dismount
-    private Location getSafeLandingLoc(Location loc) {
+    // TODO: Optimize for better dismount - completed on line 79
+    private Location getSafeLandingLoc(Location loc, Player player) {
         if (DragonTravel.getInstance().getConfigHandler().isDismountAtExactLocation())
             return loc;
+
+         // Check if the player is holding the shift key (sneaking)
+        if (player != null && player.isSneaking()) {
+            return loc;
+        }
+
         Location tempLoc = loc.clone();
         int offset = 1;
         boolean reachedFloor = false;
@@ -221,7 +227,7 @@ public class DragonManager {
         // Normal dismount
         else if (dismountAtCurrentLocation || !DragonTravel.getInstance().getConfig().getBoolean("TeleportToStartOnDismount")) {
             // Teleport player to a safe location
-            Location saveTeleportLoc = getSafeLandingLoc(player.getLocation());
+            Location saveTeleportLoc = getSafeLandingLoc(player.getLocation(), player);
 
             // Eject player and remove dragon from world
             entity.eject();


### PR DESCRIPTION
Updated the Ender Dragon riding functionality to prevent a player from dismounting from he Ender Dragon if the player is shift clicked ("sneaking" in Minecraft). Via the Bukkit/Spigot Minecraft API, I added null and player.isSneaking() checks in getSafeLandingLoc(Location loc, Player player) at "src\main\java\eu\phiwa\dragontravel\core\DragonManager.java" to cause the player's current location to be returned if sneaking. Also, I changed the reference to this method in "removeRiderAndDragon(Entity entity, Boolean dismountAtCurrentLocation), via the following: "Location saveTeleportLoc = getSafeLandingLoc(player.getLocation(), player);". Future references to getSafeLandingLoc(Location loc, Player player) should include the new added parameter "player".
